### PR TITLE
[[PRERELEASE]] Support LOGDB_PORT variable

### DIFF
--- a/25-nginx.conf.sh
+++ b/25-nginx.conf.sh
@@ -76,7 +76,6 @@ http {
         '"protocol": "$server_protocol",'
         '"method": "$request_method",'
         '"path": "$request_uri",'
-        '"req": "$request",'
         '"size": "$body_bytes_sent",'
         '"reqtime": "$request_time",'
         '"ua": "$http_user_agent",'

--- a/25-nginx.conf.sh
+++ b/25-nginx.conf.sh
@@ -67,7 +67,7 @@ http {
     log_format json escape=json '{"time": "$time_iso8601",'
         '"vhost": "$host",'
         '"xff": "$http_x_forwarded_for",'
-        '"req": "${connection}-${connection_requests}",'
+        '"conn": "$connection",'
         '"user": "$oidc_user",'
         '"group": "$oidc_group",'
         '"role1": "$oidc_role1",'

--- a/70-fluentd.conf.sh
+++ b/70-fluentd.conf.sh
@@ -66,7 +66,7 @@ cat > /etc/fluent/fluentd.conf << __EOF
 <match access.*>
   @type mongo
   host ${LOGDB_HOST}
-  port 27017
+  port ${LOGDB_PORT}
   database fluentd
   collection access
 
@@ -85,7 +85,7 @@ cat > /etc/fluent/fluentd.conf << __EOF
 </match>
 __EOF
 
-mongosh "mongodb://${LOGDB_HOST}" -u "${LOGDB_ROOT_USER}" -p "${LOGDB_ROOT_PASSWORD}" << __EOF
+mongosh "mongodb://${LOGDB_HOST}:${LOGDB_PORT}" -u "${LOGDB_ROOT_USER}" -p "${LOGDB_ROOT_PASSWORD}" << __EOF
 use fluentd;
 if (db.getUser("${LOGDB_USER}") == null) {  
   db.createUser(

--- a/70-fluentd.conf.sh
+++ b/70-fluentd.conf.sh
@@ -59,6 +59,8 @@ done
 
 entrypoint_log "$ME: info: put fluentd configuration for mongodb."
 
+LOGDB_CAPPED_SIZE=${LOGDB_CAPPED_SIZE:-1024}
+
 cat > /etc/fluent/fluentd.conf << __EOF
 @include /etc/fluent/conf.d/*.conf
 
@@ -72,7 +74,7 @@ cat > /etc/fluent/fluentd.conf << __EOF
 
   # for capped collection
   capped
-  capped_size 1024m
+  capped_size ${LOGDB_CAPPED_SIZE}m
 
   # authentication
   user ${LOGDB_USER}

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ https://qiita.com/ydclab_P002/items/b49ed23ca7b2532fcce2 を参考にKeycloak �
 |NGINX_CONFIGURE_FLUENTD|fluentd を組み込む場合 true を指定する|"true"|
 |NGINX_LOG_LEVEL|nginx のログレベルを指定した値に設定する|debug|
 |LOGDB_HOST|ログDBのホスト名|authz-db|
+|LOGDB_PORT|ログDBのポート番号|27017|
 |LOGDB_USERNAME|ログDBにアクセスするユーザ|fluentd|
 |LOGDB_PASSWORD|ログDBにアクセス際のパスワード|fluentd|
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ https://qiita.com/ydclab_P002/items/b49ed23ca7b2532fcce2 を参考にKeycloak �
 |LOGDB_PORT|ログDBのポート番号|27017|
 |LOGDB_USERNAME|ログDBにアクセスするユーザ|fluentd|
 |LOGDB_PASSWORD|ログDBにアクセス際のパスワード|fluentd|
+|LOGDB_CAPPED_SIZE|ログ用の Capped Collection のサイズ（単位MByte, デフォルト 1024）|1024|
 
 
 ## td-agent(fluentd)

--- a/README.md
+++ b/README.md
@@ -115,6 +115,30 @@ OpenID Connect の RP として動作するための location を設定する。
 access_log /var/log/nginx/access.idp.log json;
 ```
 
+ログの項目は以下の通り。
+
+|項目名|意味|値の例|
+|:----|:----|:----|
+|time |アクセスした日時|2024-05-21T00:33:30+09:00|
+|vhost |アクセスしたホスト名|procube.jp|
+|xff |アクセス元グローバルIP|112.78.125.94|
+|user |アクセスしたユーザのID|test-admin|
+|group |アクセスしたユーザのグループ|developers|
+|role1|アクセスしたユーザのロール1|IDM_ACCOUNT_MANAGER|
+|role2|アクセスしたユーザのロール2|VIEWER|
+|status |クライアントに返されたHTTPステータスコード|200|
+|protocol |HTTPリクエストのプロトコル|HTTP/1.1|
+|method |HTTPリクエストのメソッド| GET|
+|path |HTTPリクエストのパス| /|
+|size |HTTPレスポンスのサイズ|5731|
+|reqtime |レスポンスを返すまでにかかった時間(ms)|0.030|
+|ua |ユーザエージェントの値|Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML|
+|origin |アクセスしたアプリケーションのロード元|upstreamaddr |アップストリームのアドレス|10.12.21.248:80|
+|upstreamtime |アプストリームで消費した時間|0.028|
+|upstreamstatus |アップストリームから返されたHTTPステータスコード|200|
+|referrer |リファラ|https://procube.jp/dummy/|
+
+
 ## エラーログ
 
 nginx のエラーログはコンテナの標準出力に出力される。

--- a/njs/oidc.js
+++ b/njs/oidc.js
@@ -218,7 +218,7 @@ async function validate(r) {
                 if (process.env['OIDC_ROLE2_CLAIM']) {
                     r.headersOut["X-Remote-Role2"] = claims.payload[process.env['OIDC_ROLE2_CLAIM']];
                 }
-                        r.return(200);
+                r.return(200);
             }
         } else {
             r.log(`OIDC validate: fail to decode: ${my_access_token} craims:${JSON.stringify(claims)}`);


### PR DESCRIPTION
- ログフォーマットの req にコネクションIDとコネクション内通番を出力していたが、例えば、単位時間内のコネクション数をカウントする場合など、 metabase のような BI ツールで解析することを考慮してコネクション内通番を削除して項目名を conn に変更した
- ログフォーマットの req にHTTPリクエストを出力していたがmethod, path, protocol で同じ情報が取れるので、削除した
- ログフォーマットの req の出力が重複していた問題を上記により解消
- ログデータベース(mongo DB)のポート番号を環境変数で指定できるようにした。